### PR TITLE
Update 7_closed_form_copulas.ipynb

### DIFF
--- a/7_closed_form_copulas.ipynb
+++ b/7_closed_form_copulas.ipynb
@@ -65,7 +65,7 @@
     "\n",
     "A = np.linalg.cholesky(P)\n",
     "Z = np.random.normal(size=(n,d))\n",
-    "U_Gauss = norm.cdf(np.matmul(Z, A))"
+    "U_Gauss = norm.cdf(np.matmul(Z, A.T))"
    ]
   },
   {


### PR DESCRIPTION
Please have a look at the following change. Original formula should be A transposed. You may actually plot and see that unless you multiple by A transposed, columns of U_Gauss are not uniformly distributed